### PR TITLE
enable TARGET_BOARD_AUTO and select HALs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -81,4 +81,14 @@ MASTER_SIDE_CP_TARGET_LIST := msm8996
 
 include $(call all-makefiles-under,$(LOCAL_PATH))
 
+audio-hal := hardware/qcom/audio
+display-hal := hardware/qcom/display/msm8996
+gps-hal := hardware/qcom/gps/msm8994
+media-hal := hardware/qcom/media/msm8996
+
+include $(display-hal)/Android.mk
+include $(call all-makefiles-under,$(audio-hal))
+include $(call all-makefiles-under,$(gps-hal))
+include $(call all-makefiles-under,$(media-hal))
+
 endif

--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -15,6 +15,8 @@
 # Common path
 COMMON_PATH := device/sony/common
 
+TARGET_BOARD_AUTO := true
+
 TARGET_NO_RADIOIMAGE := true
 TARGET_NO_BOOTLOADER := true
 TARGET_NO_RECOVERY := false


### PR DESCRIPTION
we can ignore the platform config selection and
select which HALs will be used for our devices

Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>