### PR TITLE
move the tzfingerprint firmware

### DIFF
--- a/fingerprint/tz_api_kitakami.h
+++ b/fingerprint/tz_api_kitakami.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#define FP_TZAPP_PATH "/system/vendor/firmware/"
+#define FP_TZAPP_PATH "/etc/firmware/"
 #define FP_TZAPP_NAME "tzfingerprint"
 
 #define KM_TZAPP_PATH "/firmware/image/"

--- a/fingerprint/tz_api_loire.h
+++ b/fingerprint/tz_api_loire.h
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 
-#define FP_TZAPP_PATH "/vendor/firmware/"
+#define FP_TZAPP_PATH "/etc/firmware/"
 #define FP_TZAPP_NAME "tzfingerprint"
 
 #define KM_TZAPP_PATH "/firmware/image/"


### PR DESCRIPTION
starting from v3 zip the firmware is moved to /etc/firmware/ on
all platforms

Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>